### PR TITLE
2024-07-18

### DIFF
--- a/dbgpt/rag/knowledge/pdf.py
+++ b/dbgpt/rag/knowledge/pdf.py
@@ -57,11 +57,12 @@ class PDFKnowledge(Knowledge):
             pages = []
             page = []
             documents = []
+            pattern = re.compile(r'[\u4e00-\u9fa5]')
 
             elements = partition_pdf(self._path, strategy='hi_res', hi_res_model_name='yolox',
-                                    infer_table_structure=True,
-                                    form_extraction_skip_tables=[], languages=['chi_tra', 'chi_sim', 'eng'],
-                                    include_page_breaks=True)
+                                     infer_table_structure=True,
+                                     form_extraction_skip_tables=[], languages=['eng', 'chi_tra', 'chi_sim'],
+                                     include_page_breaks=False)
             converter = opencc.OpenCC('t2s')
 
             for element in elements:
@@ -72,14 +73,25 @@ class PDFKnowledge(Knowledge):
                 else:
                     element_id = ele_json.get('element_id')
                     element_type = ele_json.get('type')
-                    if ele_json.get('type') in [ElementType.TABLE] and ele_json.get('metadata').get('text_as_html'):
+
+                    if element_type in [ElementType.TABLE] and ele_json.get('metadata').get('text_as_html'):
                         element_text = ele_json.get('metadata').get('text_as_html')
                     else:
                         element_text = ele_json.get('text')
 
+                    # 文本清洗(后续抽象成一个方法)
+                    # 只保留指定的元素
+                    if element_type not in [ElementType.TITLE, ElementType.TEXT, ElementType.UNCATEGORIZED_TEXT, ElementType.NARRATIVE_TEXT, ElementType.PARAGRAPH, ElementType.TABLE]:
+                        continue
                     element_text = clean(element_text)
                     # 繁体中文转简体中文，后面需要对语言类型(用户输入、chunk的语言进行统一)
                     element_text = converter.convert(element_text)
+                    # 去除文本中的空格
+                    element_text = element_text.replace(' ', '')
+                    # 去除纯英文文本
+                    if not pattern.search(element_text):
+                        continue
+
                     page_number = ele_json.get('metadata').get('page_number')
                     file_name = ele_json.get('metadata').get('filename')
 
@@ -93,7 +105,7 @@ class PDFKnowledge(Knowledge):
 
             for index, page in enumerate(pages):
                 page_str = json.dumps(page, indent=2)
-                metadata = {"source": self._path, "page": index}
+                metadata = {"source": self._path}
                 document = Document(content=page_str, metadata=metadata)
                 documents.append(document)
             return documents
@@ -123,4 +135,3 @@ class PDFKnowledge(Knowledge):
     def document_type(cls) -> DocumentType:
         """Document type of PDF."""
         return DocumentType.PDF
-

--- a/dbgpt/rag/knowledge/unstructrued_element.py
+++ b/dbgpt/rag/knowledge/unstructrued_element.py
@@ -1,4 +1,6 @@
-from unstructured.documents.elements import Element, ElementMetadata
+from typing import Iterable, Optional
+
+from unstructured.documents.elements import Element, ElementMetadata, ElementType
 
 
 class CleanedElement(Element):
@@ -29,3 +31,102 @@ class CleanedMetadata(ElementMetadata):
             "filename": None if self.filename is None else self.filename,
             "page_number": None if self.page_number is None else self.page_number,
         }
+
+
+def custom_chunk_elements(
+        elements: Iterable[CleanedElement],
+        combine_text_under_n_chars: Optional[int] = 300,
+        max_characters: Optional[int] = None,
+        overlap: Optional[int] = None
+):
+    """
+    根据入参的elements列表进行组合/拆分,组合成chunks。
+    """
+    chunks = []
+    chunk = ''
+    title_index = 0
+
+    for index, element in enumerate(elements):
+        # 更新title_index
+        if element.type in [ElementType.TITLE]:
+            if chunk:
+                chunks.append(chunk)
+                chunk = ''
+
+            chunks.append(element.text)
+            title_index = len(chunks) - 1
+
+        # Table与最近的title合并成一个chunk
+        elif element.type in [ElementType.TABLE]:
+            if chunk:
+                chunks.append(chunk)
+                chunk = ''
+
+            table_text = " ".join(chunks[title_index:])
+            table_text += " " + element.text
+
+            del chunks[title_index:]
+            chunks.append(table_text)
+
+        # 判断单元素是否超过了最大字符限制
+        elif len(element.text) > max_characters:
+            if chunk:
+                chunks.append(chunk)
+                chunk = ''
+
+            # 超过限制,进行拆分
+            chunks.extend(split_element(element, max_characters, overlap))
+        # 判断最大字符限制
+        elif len(chunk) + len(element.text) > max_characters:
+            chunks.append(chunk)
+            chunk = ''
+        else:
+            chunk += ' ' + element.text
+            if index == len(list(elements)) - 1 and chunk:
+                chunks.append(chunk)
+
+    # 合并小文本
+    if combine_text_under_n_chars:
+        chunks = combine_short_text(chunks, combine_text_under_n_chars, max_characters)
+
+    return chunks
+
+
+def split_element(element: CleanedElement, max_characters: int, overlap: int):
+    start = 0
+    end = len(element.text)
+    cursor = start
+
+    splits = []
+
+    while cursor + max_characters < end:
+        splits.append(element.text[cursor:cursor + max_characters])
+        cursor += max_characters - overlap
+
+    if cursor < end:
+        splits.append(element.text[cursor:])
+
+    return splits
+
+
+def combine_short_text(chunks: Iterable[str], combine_text_under_n_chars: int, max_characters: int):
+    result_chunks = []
+    current_chunk = ''
+
+    for chunk in chunks:
+        if len(chunk) + len(current_chunk) <= max_characters:
+            if len(current_chunk) < combine_text_under_n_chars:
+                current_chunk += ' ' + chunk
+            else:
+                result_chunks.append(current_chunk)
+                current_chunk = chunk
+        else:
+            if current_chunk:
+                result_chunks.append(current_chunk)
+            current_chunk = chunk
+
+    if current_chunk:
+        result_chunks.append(current_chunk)
+
+    return result_chunks
+

--- a/dbgpt/rag/text_splitter/text_splitter.py
+++ b/dbgpt/rag/text_splitter/text_splitter.py
@@ -949,9 +949,10 @@ class UnstructruedTextSplitter(TextSplitter):
             element = CleanedElement(json_obj.get('element_id'), json_obj.get('type'), json_obj.get('text'), metadata)
             elements.append(element)
 
-        if self.chunk_strategy == 'chunk_element':
-            # 定制化切chunks策略 basic
-            chunks = custom_chunk_elements(elements, max_characters=self.max_characters, overlap=self.overlap_characters)
+        # if self.chunk_strategy == 'chunk_element':
+        # 定制化切chunks策略 basic
+        chunks = custom_chunk_elements(elements, max_characters=self.max_characters, overlap=self.overlap_characters)
+
         # else:
         #     # 定制化切chunks策略 by_title
         #     element_chunks = custom_chunk_by_title()

--- a/dbgpt/rag/text_splitter/text_splitter.py
+++ b/dbgpt/rag/text_splitter/text_splitter.py
@@ -11,7 +11,7 @@ from unstructured.chunking.title import chunk_by_title
 
 from dbgpt.core import Chunk, Document
 from dbgpt.core.awel.flow import Parameter, ResourceCategory, register_resource
-from dbgpt.rag.knowledge.unstructrued_element import CleanedMetadata, CleanedElement
+from dbgpt.rag.knowledge.unstructrued_element import CleanedMetadata, CleanedElement, custom_chunk_elements
 from dbgpt.util.i18n_utils import _
 
 logger = logging.getLogger(__name__)
@@ -950,11 +950,11 @@ class UnstructruedTextSplitter(TextSplitter):
             elements.append(element)
 
         if self.chunk_strategy == 'chunk_element':
-            element_chunks = chunk_elements(elements, max_characters=self.max_characters, overlap=self.overlap_characters)
-        else:
-            element_chunks = chunk_by_title(elements, max_characters=self.max_characters, overlap=self.overlap_characters)
-        for element in element_chunks:
-            chunks.append(element.text)
+            # 定制化切chunks策略 basic
+            chunks = custom_chunk_elements(elements, max_characters=self.max_characters, overlap=self.overlap_characters)
+        # else:
+        #     # 定制化切chunks策略 by_title
+        #     element_chunks = custom_chunk_by_title()
 
         return chunks
 


### PR DESCRIPTION
1. 保留指定元素，删除无中文元素
2. 跨页chunk
3. 自定义chunk方法:
- table不切分，和最近的title及之间内容合并
- 短文本合并

todo:
1.支持doc切分看看效果(明天完成)
...
2.提高繁体中文识别/转换精度(这周够呛完成)